### PR TITLE
Calculate max loan depending on payment schedule type

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -20,20 +20,16 @@
             "outputPath": "dist/fe-mortgage-calculator",
             "index": "src/index.html",
             "main": "src/main.ts",
-            "polyfills": [
-              "zone.js"
-            ],
+            "polyfills": ["zone.js"],
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
             "styles": [
               "@angular/material/prebuilt-themes/deeppurple-amber.css",
               "src/styles.scss"
             ],
-            "scripts": []
+            "scripts": [],
+            "baseHref": "/"
           },
           "configurations": {
             "production": {
@@ -83,16 +79,10 @@
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
-            "polyfills": [
-              "zone.js",
-              "zone.js/testing"
-            ],
+            "polyfills": ["zone.js", "zone.js/testing"],
             "tsConfig": "tsconfig.spec.json",
             "inlineStyleLanguage": "scss",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
             "styles": [
               "@angular/material/prebuilt-themes/deeppurple-amber.css",
               "src/styles.scss"

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -21,6 +21,7 @@ import { MatSliderModule } from '@angular/material/slider';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatRadioModule } from '@angular/material/radio';
+import { HttpClientModule } from '@angular/common/http';
 
 @NgModule({
   declarations: [
@@ -48,6 +49,7 @@ import { MatRadioModule } from '@angular/material/radio';
     MatFormFieldModule,
     MatSnackBarModule,
     MatRadioModule,
+    HttpClientModule,
   ],
   providers: [
     MatSnackBarModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,5 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { HashLocationStrategy, LocationStrategy } from '@angular/common';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -51,10 +50,7 @@ import { HttpClientModule } from '@angular/common/http';
     MatRadioModule,
     HttpClientModule,
   ],
-  providers: [
-    MatSnackBarModule,
-    { provide: LocationStrategy, useClass: HashLocationStrategy },
-  ],
+  providers: [MatSnackBarModule],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/src/app/interfaces/constants.ts
+++ b/src/app/interfaces/constants.ts
@@ -1,0 +1,11 @@
+export interface Constants {
+  id: number;
+  minLoanTerm: number;
+  maxLoanTerm: number;
+  maxNumOfApplicants: number;
+  loanAmountPercentage: number;
+  interestRateMargin: number;
+  maxKids: number;
+  minKids: number;
+  maxMonthlyObligationsPercentage: number;
+}

--- a/src/app/interfaces/euribor.ts
+++ b/src/app/interfaces/euribor.ts
@@ -1,0 +1,4 @@
+export interface Euribor {
+  timeInMonths: number;
+  interestRate: number;
+}

--- a/src/app/max-calc/max-calc.component.html
+++ b/src/app/max-calc/max-calc.component.html
@@ -2,34 +2,46 @@
   <form [formGroup]="maxCalcForm">
     <div class="cal-div">
       <mat-form-field class="input-wrap">
-        <mat-label>Real Estate Price</mat-label>
+        <mat-label>Real Estate Price €</mat-label>
         <input
           matInput
           formControlName="realEstatePrice"
           id="realEstatePrice"
+          (blur)="overwriteIfLess()"
         />
         <mat-error
-          *ngIf="realEstatePrice && realEstatePrice.hasError('required')"
+          *ngIf="
+            realEstatePrice &&
+            (realEstatePrice.hasError('required') ||
+              realEstatePrice.hasError('pattern'))
+          "
         >
-          Please choose an option
+          Please enter a number
         </mat-error>
         <mat-error *ngIf="realEstatePrice && realEstatePrice.hasError('max')">
-          Max is 3,000,000
+          Max is {{ maxRealEstatePrice }}
         </mat-error>
         <mat-error *ngIf="realEstatePrice && realEstatePrice.hasError('min')">
-          Min is 10,000
+          Min is {{ minRealEstatePrice }}
         </mat-error>
       </mat-form-field>
-
-      <div class="slider-cont">
-        <label id="slider-label" class="slider-label">Loan amount </label>
+      <mat-form-field class="input-wrap">
+        <mat-label>Loan amount €</mat-label>
         <input
           matInput
           formControlName="loanAmount"
           [value]="loanAmount.value"
+          (blur)="overwriteIfLess()"
         />
-        <label>€</label>
-      </div>
+        <mat-error
+          *ngIf="
+            loanAmount &&
+            (loanAmount.hasError('pattern') || loanAmount.hasError('required'))
+          "
+        >
+          Please enter a number
+        </mat-error>
+      </mat-form-field>
       <mat-slider
         class="slider-margin"
         [max]="maxLoanAmount"
@@ -43,19 +55,18 @@
         />
       </mat-slider>
 
-      <div class="slider-cont">
-        <label id="slider-label" class="slider-label">Loan term</label>
-        <input matInput formControlName="loanTerm" [value]="loanTerm.value" />
-        <label class="slider-value-label" *ngIf="loanTerm.value == 0"
-          >Years
-        </label>
-        <label class="slider-value-label" *ngIf="loanTerm.value > 1"
-          >Years
-        </label>
-        <label class="slider-value-label" *ngIf="loanTerm.value == 1"
-          >Year
-        </label>
-      </div>
+      <mat-form-field class="input-wrap">
+        <mat-label>Loan term years</mat-label>
+        <input
+          matInput
+          formControlName="loanTerm"
+          [value]="loanTerm.value"
+          (blur)="overwriteIfLess()"
+        />
+        <mat-error *ngIf="loanTerm && loanTerm.hasError('pattern')">
+          Please enter a number
+        </mat-error>
+      </mat-form-field>
       <mat-slider class="slider-margin" [max]="maxLoanTerm" [min]="minLoanTerm">
         <input
           matSliderThumb
@@ -66,12 +77,37 @@
 
       <mat-form-field class="input-wrap">
         <mat-label>Euribor</mat-label>
-        <mat-select formControlName="paymentScheduleType">
-          <mat-option *ngFor="let months of paymentSchedules" [value]="months"
-            >{{ months }} months</mat-option
+        <mat-select formControlName="euribor">
+          <mat-option *ngFor="let euribor of euriborValues" [value]="euribor"
+            >{{ euribor.timeInMonths }} Months -
+            {{ euribor.interestRate }}%</mat-option
           >
         </mat-select>
       </mat-form-field>
+      <mat-error *ngIf="loanTerm && loanTerm.hasError('pattern')">
+        Please enter a number
+      </mat-error>
+
+      <div class="obligationContainer">
+        <mat-label class="block">Payment Schedule Type</mat-label>
+        <mat-icon
+          matSuffix
+          [matTooltip]="
+            'Annuity - identical monthly installments;
+             Linear - identical monthly principle, interest is calculated on outstanding principle'
+          "
+          [matTooltipPosition]="'right'"
+          fontIcon="help_outline"
+        ></mat-icon>
+      </div>
+      <mat-radio-group
+        aria-label="Payment schedule options"
+        formControlName="paymentScheduleType"
+      >
+        <mat-radio-button value="Annuity">Annuity</mat-radio-button>
+        <mat-radio-button value="Linear">Linear</mat-radio-button>
+      </mat-radio-group>
+
       <mat-form-field class="input-wrap">
         <mat-label>Down payment</mat-label>
         <input matInput formControlName="downpayment" id="downpayment" />

--- a/src/app/max-calc/max-calc.component.html
+++ b/src/app/max-calc/max-calc.component.html
@@ -104,8 +104,8 @@
         aria-label="Payment schedule options"
         formControlName="paymentScheduleType"
       >
-        <mat-radio-button value="Annuity">Annuity</mat-radio-button>
-        <mat-radio-button value="Linear">Linear</mat-radio-button>
+        <mat-radio-button value="annuity">Annuity</mat-radio-button>
+        <mat-radio-button value="linear">Linear</mat-radio-button>
       </mat-radio-group>
 
       <mat-form-field class="input-wrap">
@@ -122,4 +122,13 @@
       <button mat-raised-button>Apply</button>
     </div>
   </form>
+  <mat-label *ngIf="linearTotal"
+    >With linear payments by the end of your mortgage you'll have paid off:
+    {{ linearTotal }} € <br
+  /></mat-label>
+
+  <mat-label *ngIf="annuityTotal"
+    >With annuity payments by the end of your mortgage you'll have paid off:
+    {{ annuityTotal }} € <br
+  /></mat-label>
 </div>

--- a/src/app/max-calc/max-calc.component.html
+++ b/src/app/max-calc/max-calc.component.html
@@ -1,5 +1,5 @@
 <div class="container">
-  <form [formGroup]="maxCalcForm">
+  <form [formGroup]="maxCalcForm" (ngSubmit)="calculateMax()">
     <div class="cal-div">
       <mat-form-field class="input-wrap">
         <mat-label>Real Estate Price €</mat-label>
@@ -116,11 +116,10 @@
         <mat-label>Interest Rate</mat-label>
         <input matInput formControlName="interestRate" />
       </mat-form-field>
+      <button class="btn-calculate" mat-raised-button type="submit">
+        Calculate
+      </button>
+      <button mat-raised-button>Apply</button>
     </div>
   </form>
-
-  <button class="btn-calculate" mat-raised-button type="submit">
-    Calculate
-  </button>
-  <button mat-raised-button>Apply</button>
 </div>

--- a/src/app/max-calc/max-calc.component.scss
+++ b/src/app/max-calc/max-calc.component.scss
@@ -1,6 +1,6 @@
 .container {
   text-align: center;
-  margin-top: 100px;
+  margin-top: 20px;
   .cal-div {
     display: inline-block;
     min-width: 150px;

--- a/src/app/max-calc/max-calc.component.ts
+++ b/src/app/max-calc/max-calc.component.ts
@@ -4,6 +4,8 @@ import { TooltipPosition } from '@angular/material/tooltip';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { debounceTime } from 'rxjs';
 import { Euribor } from '../interfaces/euribor';
+import { ApiService } from '../services/api.service';
+import { Constants } from '../interfaces/constants';
 
 const fb = new FormBuilder().nonNullable;
 
@@ -19,6 +21,7 @@ export class MaxCalcComponent {
   minLoanTerm: number = 1;
   maxLoanTerm: number = 30;
   baseInterest: number = 2.5;
+  constants: Constants;
   euriborValues: Euribor[] = [
     {
       timeInMonths: 3,
@@ -78,7 +81,7 @@ export class MaxCalcComponent {
   );
 
   maxLoanAmount: number = this.realEstatePrice.value * 0.85;
-  constructor(private _snackBar: MatSnackBar) {
+  constructor(private _snackBar: MatSnackBar, private api: ApiService) {
     this.loanAmount.addValidators(Validators.max(this.maxLoanAmount));
     this.realEstatePrice.valueChanges
       .pipe(debounceTime(10))
@@ -148,7 +151,16 @@ export class MaxCalcComponent {
     this.downpayment.disable();
   }
 
-  ngOnInit() {}
+  ngOnInit() {
+    this.api.getConstants().subscribe((constants) => {
+      this.constants = constants;
+      console.log(this.constants);
+    });
+  }
+
+  calculateMax() {
+    throw new Error('Method not implemented.');
+  }
 
   overwriteIfLess() {
     if (this.realEstatePrice.value < this.minRealEstatePrice) {
@@ -169,17 +181,6 @@ export class MaxCalcComponent {
       });
     }
   }
-
-  positionOptions: TooltipPosition[] = [
-    'after',
-    'before',
-    'above',
-    'below',
-    'left',
-    'right',
-  ];
-  position = this.positionOptions[2];
-  realEst: number;
 
   get euribor() {
     return this.maxCalcForm.get('euribor');

--- a/src/app/max-calc/max-calc.component.ts
+++ b/src/app/max-calc/max-calc.component.ts
@@ -168,13 +168,11 @@ export class MaxCalcComponent {
       this.linearTotal = this.calcService.calculateLinearTotal(
         this.maxCalcForm
       );
-      console.log('linear total: ', this.linearTotal);
     }
     if (this.maxCalcForm && this.paymentScheduleType.value == 'annuity') {
       this.annuityTotal = this.calcService.calculateAnnuityTotal(
         this.maxCalcForm
       );
-      console.log('annuity total: ', this.annuityTotal);
     }
   }
 

--- a/src/app/services/api.service.spec.ts
+++ b/src/app/services/api.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ApiService } from './api.service';
+
+describe('ApiService', () => {
+  let service: ApiService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ApiService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -1,0 +1,19 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Constants } from '../interfaces/constants';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ApiService {
+  private apiUrl = 'https://be-mortgage-calculator.onrender.com/api';
+
+  constants: Constants;
+
+  constructor(private http: HttpClient) {}
+
+  getConstants(): Observable<Constants> {
+    return this.http.get<Constants>(`${this.apiUrl}/constants`);
+  }
+}

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -7,7 +7,7 @@ import { Constants } from '../interfaces/constants';
   providedIn: 'root',
 })
 export class ApiService {
-  private apiUrl = 'https://be-mortgage-calculator.onrender.com/api';
+  private apiUrl = 'https://be-mortgage-calculator.onrender.com/api/v1';
 
   constants: Constants;
 

--- a/src/app/services/maxcalculations.service.spec.ts
+++ b/src/app/services/maxcalculations.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { MaxcalculationsService } from './maxcalculations.service';
+
+describe('MaxcalculationsService', () => {
+  let service: MaxcalculationsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(MaxcalculationsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/maxcalculations.service.ts
+++ b/src/app/services/maxcalculations.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class MaxcalculationsService {
+  constructor() {}
+
+  calculateLinear() {}
+
+  calculateAnnuity() {}
+}

--- a/src/app/services/maxcalculations.service.ts
+++ b/src/app/services/maxcalculations.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { FormGroup, NumberValueAccessor } from '@angular/forms';
 
 @Injectable({
   providedIn: 'root',
@@ -6,7 +7,50 @@ import { Injectable } from '@angular/core';
 export class MaxcalculationsService {
   constructor() {}
 
-  calculateLinear() {}
+  maxForm: FormGroup;
+  outstandingPrincipal: number;
+  loanTermInMonths: number;
+  monthlyInterestRate: number;
+  linearTotal: number;
+  setForm(form: FormGroup) {
+    this.maxForm = form;
+    this.outstandingPrincipal = this.loanAmount.value;
+    this.loanTermInMonths = this.loanTerm.value * 12;
+    this.monthlyInterestRate = this.interestRate.value / 100 / 12;
+    this.linearTotal = 0;
+  }
 
-  calculateAnnuity() {}
+  calculateLinearTotal(form: FormGroup): number {
+    this.setForm(form);
+    const principal = this.loanAmount.value / this.loanTermInMonths;
+    while (this.outstandingPrincipal > 0) {
+      this.linearTotal +=
+        principal + this.monthlyInterestRate * this.outstandingPrincipal;
+      this.outstandingPrincipal -= principal;
+    }
+    return parseFloat(this.linearTotal.toFixed(2));
+  }
+
+  calculateAnnuityTotal(form: FormGroup): number {
+    this.setForm(form);
+    const monthlyAnnuity = this.calculateAnnuityMonthly();
+    return parseFloat((monthlyAnnuity * this.loanTermInMonths).toFixed(2));
+  }
+
+  calculateAnnuityMonthly(): number {
+    const monthlyAnnuity =
+      (this.loanAmount.value * this.monthlyInterestRate) /
+      (1 - Math.pow(1 + this.monthlyInterestRate, -this.loanTermInMonths));
+    return monthlyAnnuity;
+  }
+
+  get loanAmount() {
+    return this.maxForm.get('loanAmount');
+  }
+  get interestRate() {
+    return this.maxForm.get('interestRate');
+  }
+  get loanTerm() {
+    return this.maxForm.get('loanTerm');
+  }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -12,6 +12,10 @@
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500&display=swap"
       rel="stylesheet"
     />
+    <link
+      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <app-root></app-root>


### PR DESCRIPTION
### New features and updates
1. Added radio for payment schedule type (either linear or annuity)
2. Created individual rows for inputs that have sliders so it looks better
3. Added interfaces for constants and euribor
4. Created an api service to fetch constants from the back-end (values such as interest rate are still currently hard-coded)
5. Created maximum calculation service to calculate total amount paid for both linear and annuity schedule type payments
6. Implemented maximum calculation service